### PR TITLE
display_zed2: Fix default camera model param

### DIFF
--- a/zed_display_rviz/launch/display_zed2.launch
+++ b/zed_display_rviz/launch/display_zed2.launch
@@ -20,7 +20,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     <arg name="svo_file"             default="" /> <!-- <arg name="svo_file" default="path/to/svo/file.svo"> -->
     <arg name="stream"               default="" /> <!-- <arg name="stream" default="<ip_address>:<port>"> -->
 
-    <arg name="camera_model"         default="zed2i" />
+    <arg name="camera_model"         default="zed2" />
 
     <!-- Launch ZED camera wrapper -->
     <include file="$(find zed_wrapper)/launch/$(arg camera_model).launch">


### PR DESCRIPTION
https://github.com/stereolabs/zed-ros-examples/commit/d6a00e3b9815311b364af2a986346eb425c3ecf4 probably has a typo