### PR TITLE
fix param namespace for svo_file

### DIFF
--- a/examples/zed_multicamera_example/launch/include/zed_camera_mod.launch
+++ b/examples/zed_multicamera_example/launch/include/zed_camera_mod.launch
@@ -72,7 +72,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
         <param name="general/camera_name"               value="$(arg camera_name)" />
 
         <!-- SVO file path -->
-        <param name="general/svo_file"                  value="$(arg svo_file)" />
+        <param name="svo_file"                  value="$(arg svo_file)" />
 
         <!-- Remote stream -->
         <param name="general/stream"                    value="$(arg stream)" />


### PR DESCRIPTION
The param "svo_file" is not in the namespace general. 