### PR TITLE
Correct plugin so it can show more than one instance of each category

### DIFF
--- a/rviz-plugin-zed-od/src/plugin/src/zed_od_display.cpp
+++ b/rviz-plugin-zed-od/src/plugin/src/zed_od_display.cpp
@@ -153,7 +153,7 @@ void ZedOdDisplay::processMessage(const zed_interfaces::ObjectsStamped::ConstPtr
 
 void ZedOdDisplay::createOrUpdateObject(zed_interfaces::Object& obj)
 {
-  int16_t id = obj.label_id;
+  int16_t id = obj.instance_id;
   if (id == -1 && obj.tracking_available) // Not a valid ID?
   {
     return;


### PR DESCRIPTION
The 'id' used is the 'label_id', instead of 'instance_id'. For this reason, rviz is not showing more than one instance of each category. This PR corrects this problem.